### PR TITLE
Remove deprecated `basic_path`. Use path instead

### DIFF
--- a/include/detail/datasource.hpp
+++ b/include/detail/datasource.hpp
@@ -213,10 +213,9 @@ class directory_iterator : boost::noncopyable
     }
 
   private:
-    //typedef
-    //boost::filesystem::basic_path<std::string, boost::filesystem::path_traits>
-    //path_t;
-    typedef boost::filesystem::path path_t;
+    typedef
+        boost::filesystem::path
+        path_t;
 
     mutable boost::filesystem::directory_iterator it_dir_;
     std::string                     directory_;


### PR DESCRIPTION
`boost::filesystem::basic_path` is removed in boost-1.50.
