### PR TITLE
add forward declaration for compilation on OSX with g++ 4.8.0

### DIFF
--- a/include/detail/intermediates/local_disk.hpp
+++ b/include/detail/intermediates/local_disk.hpp
@@ -45,6 +45,8 @@ struct null_combiner;
 
 namespace detail {
 
+template<typename T> uintmax_t const length(T const & value);
+
 struct file_lines_comp
 {
     template<typename T>


### PR DESCRIPTION
Hi Craig,

this is just a minor fix to let me compile the test on my OSX (10.7.5) with my gcc-suite (4.8.0).

Cheers,
Daniel
